### PR TITLE
[Fix] - Maximum recursion for managers

### DIFF
--- a/docs/managers.md
+++ b/docs/managers.md
@@ -21,9 +21,15 @@ the **Manager** class and override the `get_queryset()`.
 
 For those familiar with Django managers, the principle is exactly the same. 😀
 
+**The managers must be type annotated ClassVar** or an `ImproperlyConfigured` exception will be raised.
+
+```python hl_lines="19"
+{!> ../docs_src/models/managers/example.py !}
+```
+
 Let us now create new manager and use it with our previous example.
 
-```python hl_lines="24 40 43 46 53"
+```python hl_lines="26 42 45 48 55"
 {!> ../docs_src/models/managers/custom.py !}
 ```
 
@@ -35,7 +41,7 @@ simply override the `get_queryset()` and add it to your models.
 Overriding the default manager is also possible by creating the custom manager and overriding
 the `query` manager.
 
-```python hl_lines="24 37 40 43 46"
+```python hl_lines="26 39 42 45 48"
 {!> ../docs_src/models/managers/override.py !}
 ```
 

--- a/docs_src/models/managers/custom.py
+++ b/docs_src/models/managers/custom.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 import edgy
 from edgy import Database, Manager, QuerySet, Registry
 
@@ -21,7 +23,7 @@ class User(edgy.Model):
     is_active: bool = edgy.BooleanField(default=True)
 
     # Add the new manager
-    inactives: Manager = InactiveManager()
+    inactives: ClassVar[Manager] = InactiveManager()
 
     class Meta:
         registry = models

--- a/docs_src/models/managers/example.py
+++ b/docs_src/models/managers/example.py
@@ -1,0 +1,19 @@
+from typing import ClassVar
+
+import edgy
+from edgy import Manager, QuerySet
+
+
+class InactiveManager(Manager):
+    """
+    Custom manager that will return only active users
+    """
+
+    def get_queryset(self) -> "QuerySet":
+        queryset = super().get_queryset().filter(is_active=False)
+        return queryset
+
+
+class User(edgy.Model):
+    # Add the new manager
+    inactives: ClassVar[Manager] = InactiveManager()

--- a/docs_src/models/managers/override.py
+++ b/docs_src/models/managers/override.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 import edgy
 from edgy import Database, Manager, QuerySet, Registry
 
@@ -21,7 +23,7 @@ class User(edgy.Model):
     is_active: bool = edgy.BooleanField(default=True)
 
     # Add the new manager
-    query: Manager = InactiveManager()
+    query: ClassVar[Manager] = InactiveManager()
 
     class Meta:
         registry = models

--- a/edgy/core/db/fields/core.py
+++ b/edgy/core/db/fields/core.py
@@ -10,6 +10,7 @@ from typing import Any, Optional, Pattern, Sequence, Set, Tuple, Union
 
 import pydantic
 import sqlalchemy
+from pydantic import EmailStr
 
 from edgy.core.db.fields._internal import IPAddress
 from edgy.core.db.fields._validators import IPV4_REGEX, IPV6_REGEX
@@ -482,7 +483,7 @@ class PasswordField(CharField):
 
 
 class EmailField(CharField):
-    _type = str
+    _type = EmailStr
 
     @classmethod
     def get_column_type(self, **kwargs: Any) -> sqlalchemy.String:

--- a/edgy/core/db/models/managers.py
+++ b/edgy/core/db/models/managers.py
@@ -42,12 +42,12 @@ class Manager:
         Checks for a global possible tenant and returns the corresponding queryset.
         """
         tenant = get_tenant()
-        if tenant:
+        if tenant is not None:
             set_tenant(None)
             return QuerySet(
                 self.model_class, table=self.model_class.table_schema(tenant)  # type: ignore
             )
-        return QuerySet(self.model_class)
+        return QuerySet(self.model_class)  # type: ignore
 
     def __getattr__(self, item: Any) -> Any:
         """

--- a/edgy/core/db/models/managers.py
+++ b/edgy/core/db/models/managers.py
@@ -42,12 +42,12 @@ class Manager:
         Checks for a global possible tenant and returns the corresponding queryset.
         """
         tenant = get_tenant()
-        if tenant is not None:
+        if tenant:
             set_tenant(None)
             return QuerySet(
                 self.model_class, table=self.model_class.table_schema(tenant)  # type: ignore
             )
-        return QuerySet(self.model_class)  # type: ignore
+        return QuerySet(self.model_class)
 
     def __getattr__(self, item: Any) -> Any:
         """

--- a/tests/managers/test_manager_error.py
+++ b/tests/managers/test_manager_error.py
@@ -1,0 +1,52 @@
+import pytest
+from tests.settings import DATABASE_URL
+
+import edgy
+from edgy import Manager
+from edgy.core.db.querysets import QuerySet
+from edgy.exceptions import ImproperlyConfigured
+from edgy.testclient import DatabaseTestClient as Database
+
+database = Database(url=DATABASE_URL)
+models = edgy.Registry(database=database)
+
+pytestmark = pytest.mark.anyio
+
+
+class UserManager(Manager):
+    def get_queryset(self) -> QuerySet:
+        queryset = super().get_queryset().filter(is_admin=False)
+        return queryset
+
+
+async def test_raise_improperly_configured_on_missing_annotation():
+    with pytest.raises(ImproperlyConfigured) as raised:
+
+        class User(edgy.Model):
+            username: str = edgy.CharField(max_length=150)
+            is_admin: bool = edgy.BooleanField(default=True)
+
+            mang = UserManager()
+
+            class Meta:
+                registry = models
+
+    assert (
+        raised.value.args[0]
+        == "Managers must be type annotated and 'mang' is not annotated. Managers must be annotated with ClassVar."
+    )
+
+
+async def test_raise_improperly_configured_on_wrong_annotation():
+    with pytest.raises(ImproperlyConfigured) as raised:
+
+        class User(edgy.Model):
+            username: str = edgy.CharField(max_length=150)
+            is_admin: bool = edgy.BooleanField(default=True)
+
+            mang: Manager = UserManager()
+
+            class Meta:
+                registry = models
+
+    assert raised.value.args[0] == "Managers must be ClassVar type annotated."

--- a/tests/managers/test_manager_simple.py
+++ b/tests/managers/test_manager_simple.py
@@ -1,0 +1,69 @@
+from datetime import date
+from typing import ClassVar
+
+import pytest
+from tests.settings import DATABASE_URL
+
+import edgy
+from edgy import Manager
+from edgy.core.db.querysets import QuerySet
+from edgy.testclient import DatabaseTestClient as Database
+
+database = Database(url=DATABASE_URL)
+models = edgy.Registry(database=database)
+
+pytestmark = pytest.mark.anyio
+
+
+class UserManager(Manager):
+    def get_queryset(self) -> QuerySet:
+        queryset = super().get_queryset().filter(is_admin=False)
+        return queryset
+
+
+class User(edgy.Model):
+    password: str = edgy.CharField(max_length=128)
+    username: str = edgy.CharField(max_length=150, unique=True)
+    email: str = edgy.EmailField(max_length=120, unique=True)
+    is_active: bool = edgy.BooleanField(default=True)
+    is_student: bool = edgy.BooleanField(default=True)
+    is_teacher: bool = edgy.BooleanField(default=True)
+    is_admin: bool = edgy.BooleanField(default=True)
+    is_staff: bool = edgy.BooleanField(default=False)
+    created_at: date = edgy.DateField(auto_now_add=True)
+
+    mang: ClassVar[Manager] = UserManager()
+
+    class Meta:
+        registry = models
+
+
+@pytest.fixture(autouse=True, scope="function")
+async def create_test_database():
+    await models.create_all()
+    yield
+    await models.drop_all()
+
+
+@pytest.fixture(autouse=True)
+async def rollback_connections():
+    with database.force_rollback():
+        async with database:
+            yield
+
+
+async def test_can_create_record():
+    await User.mang.create(password="12345", username="user", email="test@test.com")
+
+    users = await User.mang.all()
+
+    assert len(users) == 0
+
+    user = await User.mang.create(
+        password="12345", username="user2", email="test1@test.com", is_admin=False
+    )
+
+    users = await User.mang.all()
+
+    assert len(users) == 1
+    assert users[0].pk == user.pk


### PR DESCRIPTION
- Maximum recursion was being triggered when a manager was declared but not annotated with `ClassVar`.

Example

```python
import edgy
from edgy import Manager
from edgy.core.db.querysets import QuerySet

class UserManager(Manager):
    def get_queryset(self) -> QuerySet:
        queryset = super().get_queryset().filter(is_admin=False)
        return queryset

class User(edgy.Model):
    username: str = edgy.CharField(max_length=150)
    is_admin: bool = edgy.BooleanField(default=True)

    mang = UserManager()

    class Meta:
        registry = models
```

This causes a maximum recursion in the internal validations.

## Solution

For the `managers` to be type annotated `ClassVar` and raise `ImproperlyConfigured` exception when that does not happen.
