### PR TITLE
Missing unique attribute for 'unique together'

### DIFF
--- a/docs_src/models/unique_together/simple.py
+++ b/docs_src/models/unique_together/simple.py
@@ -7,7 +7,7 @@ models = Registry(database=database)
 
 class User(edgy.Model):
     name: str = edgy.CharField(max_length=255)
-    email: str = edgy.EmailField(max_length=70)
+    email: str = edgy.EmailField(max_length=70, unique=True)
     is_active: bool = edgy.BooleanField(default=True)
 
     class Meta:


### PR DESCRIPTION
Through [this ](https://edgy.tarsild.io/models/#simple-unique-together) example, the use of attribution `unique` is mentioned, but never actually used in the example. 