### PR TITLE
Feature:merged meta

### DIFF
--- a/edgy/cli/cli.py
+++ b/edgy/cli/cli.py
@@ -9,7 +9,12 @@ from functools import wraps
 
 import click
 
-from edgy.cli.constants import APP_PARAMETER, EXCLUDED_COMMANDS, HELP_PARAMETER, IGNORE_COMMANDS
+from edgy.cli.constants import (
+    APP_PARAMETER,
+    EXCLUDED_COMMANDS,
+    HELP_PARAMETER,
+    IGNORE_COMMANDS,
+)
 from edgy.cli.env import MigrationEnv
 from edgy.cli.operations import (
     check,
@@ -38,7 +43,9 @@ printer = Print()
 class EdgyGroup(click.Group):
     """Edgy command group with extras for the commands"""
 
-    def add_command(self, cmd: click.Command, name: typing.Optional[str] = None) -> None:
+    def add_command(
+        self, cmd: click.Command, name: typing.Optional[str] = None
+    ) -> None:
         if cmd.callback:
             cmd.callback = self.wrap_args(cmd.callback)
         return super().add_command(cmd, name)
@@ -47,7 +54,9 @@ class EdgyGroup(click.Group):
         params = inspect.signature(func).parameters
 
         @wraps(func)
-        def wrapped(ctx: click.Context, /, *args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+        def wrapped(
+            ctx: click.Context, /, *args: typing.Any, **kwargs: typing.Any
+        ) -> typing.Any:
             scaffold = ctx.ensure_object(MigrationEnv)
             if "env" in params:
                 kwargs["env"] = scaffold

--- a/edgy/core/db/models/base.py
+++ b/edgy/core/db/models/base.py
@@ -27,7 +27,6 @@ from edgy.core.db.models._internal import DescriptiveMeta
 from edgy.core.db.models.managers import Manager
 from edgy.core.db.models.metaclasses import (
     BaseModelMeta,
-    BaseModelReflectMeta,
     MetaInfo,
 )
 from edgy.core.db.models.model_proxy import ProxyModel
@@ -56,6 +55,7 @@ class EdgyBaseModel(BaseModel, DateParser, ModelParser, metaclass=BaseModelMeta)
     Meta: ClassVar[DescriptiveMeta] = DescriptiveMeta()
     __proxy_model__: ClassVar[Union[Type["Model"], None]] = None
     __db_model__: ClassVar[bool] = False
+    __reflected__: ClassVar[bool] = False
     __raw_query__: ClassVar[Optional[str]] = None
     __using_schema__: ClassVar[Union[str, None]] = None
     __model_references__: ClassVar[Any] = None
@@ -297,11 +297,13 @@ class EdgyBaseModel(BaseModel, DateParser, ModelParser, metaclass=BaseModelMeta)
         return True
 
 
-class EdgyBaseReflectModel(EdgyBaseModel, metaclass=BaseModelReflectMeta):
+class EdgyBaseReflectModel(EdgyBaseModel):
     """
     Reflect on async engines is not yet supported, therefore, we need to make a sync_engine
     call.
     """
+
+    __reflected__: ClassVar[bool] = True
 
     @classmethod
     @functools.lru_cache


### PR DESCRIPTION
Changes:
- add a class variable named `__reflected__`, this way we doesn't need to change anything else
<del>- fix some deprecation warnings</del>
   - use and_ and or_ of the clauses module (can handle empty args)
   - replace deprecated httpx app argument

Note: there should be also a small speed benefit by putting the model in the right registry in the first place