### PR TITLE
Fix linting with ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,9 @@ disable_error_code = "attr-defined,arg-type,override,misc"
 warn_unused_ignores = true
 warn_redundant_casts = true
 
+[tool.ruff]
+line-length = 120
+
 [tool.ruff.lint]
 select = ["E", "W", "F", "C", "B", "I"]
 ignore = ["E501", "B008", "C901", "B026"]


### PR DESCRIPTION
Currently ruff can use the line length the user prefers (or which he accidentally activates) which leads to many changes in commits.

This PR directs ruff to use the line-length of 120 which is also specified in .editorconfig