### PR TITLE
Feature: rename to_python to to_model

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -557,8 +557,8 @@ Fields have to inherit from `edgy.db.fields.base.BaseField` and to provide follo
 
 Additional they can provide following methods:
 * **`__get__`** - Descriptor protocol like get access customization.
-* **`__set__`** - Descriptor protocol like set access customization. Dangerous to use. Better use to_python.
-* **to_python** - like clean, just for setting attributes or initializing a model.
+* **`__set__`** - Descriptor protocol like set access customization. Dangerous to use. Better use to_model.
+* **to_model** - like clean, just for setting attributes or initializing a model.
 * **get_embedded_fields(self, field_name, field_mapping)** - Define internal fields.
 * **get_default_values(self, field_name, cleaned_data)** - returns the default values for the field. Can provide default values for embedded fields. If your field spans only one column you can also use the simplified get_default_value instead. This way you don't have to check for collisions. By default get_default_value is used internally.
 * **get_default_value(self)** - return default value for one column fields.

--- a/edgy/core/db/fields/many_to_many.py
+++ b/edgy/core/db/fields/many_to_many.py
@@ -131,6 +131,9 @@ class BaseManyToManyForeignKeyField(BaseForeignKey):
         """Checks if the field has a default value set"""
         return hasattr(self, "default")
 
+    def expand_relationship(self, value: Any) -> Any:
+        return value
+
 
 class ManyToManyField(ForeignKeyFieldFactory):
     _type: Any = Any

--- a/edgy/core/db/models/model.py
+++ b/edgy/core/db/models/model.py
@@ -88,7 +88,7 @@ class Model(ModelRow, DeclarativeMixin):
         awaitable = await self.database.execute(expression)
         if not awaitable:
             awaitable = pk_to_dict(self, kwargs)
-        for k, v in self.fields["pk"].to_python("pk", awaitable).items():
+        for k, v in self.fields["pk"].to_model("pk", awaitable, phase="set").items():
             setattr(self, k, v)
         return self
 


### PR DESCRIPTION
Changes:
- rename to_python to to_model and add phase as argument to it
- use expand_relationship only in BaseForeignKey and descendants and remove it from BaseField

TODO:
- find out why using settings in ManyToMany caused problems